### PR TITLE
allow a secret or secret-file when bootstrapping a new server

### DIFF
--- a/lib/chef/knife/brightbox_server_create.rb
+++ b/lib/chef/knife/brightbox_server_create.rb
@@ -93,6 +93,17 @@ class Chef
         :proc => lambda { |o| o.split(/[\s,]+/) },
         :default => []
 
+      option :secret,
+        :short => "-s SECRET",
+        :long => "--secret ",
+        :description => "The secret key to use to encrypt data bag item values",
+        :proc => lambda { |s| Chef::Config[:knife][:secret] = s }
+
+      option :secret_file,
+        :long => "--secret-file SECRET_FILE",
+        :description => "A file containing the secret key to use to encrypt data bag item values",
+        :proc => lambda { |sf| Chef::Config[:knife][:secret_file] = sf }
+
       option :ssh_user,
         :short => "-x USERNAME",
         :long => "--ssh-user USERNAME",


### PR DESCRIPTION
This will simply add support for the `--secret-file` and `--secret` flags. Everything else is handled by knife out-of-the-box
