### PR TITLE
Let the server name be specified just once.

### DIFF
--- a/lib/chef/knife/brightbox_server_create.rb
+++ b/lib/chef/knife/brightbox_server_create.rb
@@ -164,7 +164,7 @@ class Chef
 
         print "#{ui.color("Creating server... ", :magenta)}"
         server = connection.servers.create(
-          :name => config[:server_name],
+          :name => config[:server_name] || config[:chef_node_name],
           :image_id => Chef::Config[:knife][:image],
           :zone_id => zone_id,
           :flavor_id => Chef::Config[:knife][:flavor] || config[:flavor]
@@ -223,7 +223,7 @@ class Chef
         bootstrap.config[:run_list] = config[:run_list]
         bootstrap.config[:ssh_user] = config[:ssh_user] || "root"
         bootstrap.config[:identity_file] = config[:identity_file]
-        bootstrap.config[:chef_node_name] = config[:chef_node_name] || server.id
+        bootstrap.config[:chef_node_name] = config[:chef_node_name] || server.name || server.id
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:distro] = locate_config_value(:distro)
         # bootstrap will run as root...sudo (by default) also messes up Ohai on CentOS boxes


### PR DESCRIPTION
If only one of '--server-name' or '-N' (chef node name) is given, use
that name for both attributes, and only fall back to the server ID for
the Chef node name if there's no names given at all.

This makes it much simpler to keep the same name on Brightbox and in
Chef, especially if you use autogenerated names (you can just use
backticks and call your autogeneration program in the command-line).
