### PR TITLE
Allow command-line override: use `config` instead of Chef::Config[:knife]

### DIFF
--- a/lib/chef/knife/brightbox_server_create.rb
+++ b/lib/chef/knife/brightbox_server_create.rb
@@ -157,7 +157,7 @@ class Chef
       def run
         $stdout.sync = true
 
-        unless Chef::Config[:knife][:image]
+        unless config[:image]
           ui.error("You have not provided a valid image value.  Please note the short option for this value recently changed from '-i' to '-I'.")
           exit 1
         end
@@ -165,9 +165,9 @@ class Chef
         print "#{ui.color("Creating server... ", :magenta)}"
         server = connection.servers.create(
           :name => config[:server_name] || config[:chef_node_name],
-          :image_id => Chef::Config[:knife][:image],
+          :image_id => config[:image],
           :zone_id => zone_id,
-          :flavor_id => Chef::Config[:knife][:flavor] || config[:flavor]
+          :flavor_id => config[:flavor]
         )
         puts " done \n"
 
@@ -249,7 +249,7 @@ class Chef
       end
 
       def zone_id
-        zone_handle = Chef::Config[:knife][:zone] || config[:zone]
+        zone_handle = config[:zone]
 
         begin
           zones.fetch(zone_handle)


### PR DESCRIPTION
I ran into a problem the other day. I have a `knife[:image]` set in my `.chef/knife.rb`, because we've always used the current image for our OS of choice to bootstrap new servers. But now we want to bootstrap some servers from snapshots, so we can hot-swap faster in case of a disaster.

The current version of knife-brightbox doesn't allow to override a knife attribute that's been set in `knife.rb`. This pull request allows it.

*A word of warning*: This has only been tried with Chef 11, I don't use 10 anymore (and haven't switched to 12 yet) so I'm not sure if it behaves the same way.